### PR TITLE
Include request type so exchange recognizes ics.

### DIFF
--- a/lib/icalevent.js
+++ b/lib/icalevent.js
@@ -65,6 +65,7 @@ iCalEvent.prototype = {
 	toFile: function(){
 		var result = '';
 		result += 'BEGIN:VCALENDAR\n';
+		result += 'METHOD:REQUEST\n';
 		result += 'BEGIN:VEVENT\n';
 		result += 'UID:' + this.uid + '\n';
 		result += 'DTSTAMP:' + this.format(new Date()) + '\n';


### PR DESCRIPTION
Added method 'REQUEST' to default header. With this flag exchange recognizes the ics as a proper meeting request.
