### PR TITLE
Allow setting the event uid

### DIFF
--- a/lib/icalevent.js
+++ b/lib/icalevent.js
@@ -3,10 +3,17 @@ var tzone = require('tzone');
 
 var iCalEvent = function(event){
 	this.id = '-//iCalEvent.js v0.3//EN';
-	this.uid = this.uid();
+
+	if (event&&event.uid){
+		this.uid = event.uid;
+	}
+	else {
+		this.uid = this.uid();
+	}
+
 	this.event = {};
 	if (event) this.create(event);
-}
+};
 
 iCalEvent.prototype = {
 

--- a/lib/icalevent.js
+++ b/lib/icalevent.js
@@ -4,15 +4,14 @@ var tzone = require('tzone');
 var iCalEvent = function(event){
 	this.id = '-//iCalEvent.js v0.3//EN';
 
+	this.event = {};
+	if (event) this.create(event);
 	if (event&&event.uid){
 		this.uid = event.uid;
 	}
 	else {
 		this.uid = this.uid();
 	}
-
-	this.event = {};
-	if (event) this.create(event);
 };
 
 iCalEvent.prototype = {


### PR DESCRIPTION
If the event.uid is defined, it is used as the event's uid.
Otherwise, a uid is generated.

Necessary when trying to send modifications and cancellations of events.
